### PR TITLE
Use external CDP browser for PDF rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Key variables (see `apps/web/env.example` and `apps/api/env.example` for full li
 - `ADMIN_PASSWORD` – password required to log into `/admin`.
 - `DATABASE_URL` (API env) – Postgres connection string for API runtime/migrations.
 - `GOOGLE_CLOUD_*` (API env) – GCS configuration for image operations.
+- `PDF_BROWSER_CDP_URL` (API env) – optional CDP endpoint used for PDF rendering.
 
 ## Installing Dependencies
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ environment, set `PLAYWRIGHT_BASE_URL` before running `cd apps/web && bun run te
 
 - Ensure all required env vars (`apps/web` + `apps/api`) are set in the target environment.
 - Deploy using the standalone output (`cd apps/web && bun run build` then `cd apps/web && bun run start`, or the provided `apps/web/Dockerfile`).
-- API Docker builds include Playwright Chromium by default. For CDP-only PDF
-  rendering, build with `--build-arg INSTALL_PLAYWRIGHT_CHROMIUM=false` and set
-  `PDF_BROWSER_CDP_URL` at runtime.
+- API Docker builds skip bundled Playwright Chromium by default. Set
+  `PDF_BROWSER_CDP_URL` at runtime for CDP PDF rendering, or build with
+  `--build-arg INSTALL_PLAYWRIGHT_CHROMIUM=true` to include builtin Chromium.
 - Prefer service account credentials via environment variables for production.

--- a/README.md
+++ b/README.md
@@ -151,4 +151,7 @@ environment, set `PLAYWRIGHT_BASE_URL` before running `cd apps/web && bun run te
 
 - Ensure all required env vars (`apps/web` + `apps/api`) are set in the target environment.
 - Deploy using the standalone output (`cd apps/web && bun run build` then `cd apps/web && bun run start`, or the provided `apps/web/Dockerfile`).
+- API Docker builds include Playwright Chromium by default. For CDP-only PDF
+  rendering, build with `--build-arg INSTALL_PLAYWRIGHT_CHROMIUM=false` and set
+  `PDF_BROWSER_CDP_URL` at runtime.
 - Prefer service account credentials via environment variables for production.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM oven/bun:1.3.12-slim AS deps
 WORKDIR /app
-ARG INSTALL_PLAYWRIGHT_CHROMIUM=true
+ARG INSTALL_PLAYWRIGHT_CHROMIUM=false
 
 COPY package.json bun.lock ./
 COPY apps/api/package.json ./apps/api/package.json
@@ -21,7 +21,7 @@ RUN if [ "$INSTALL_PLAYWRIGHT_CHROMIUM" = "true" ]; then \
 
 FROM oven/bun:1.3.12-slim AS runner
 WORKDIR /app
-ARG INSTALL_PLAYWRIGHT_CHROMIUM=true
+ARG INSTALL_PLAYWRIGHT_CHROMIUM=false
 
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -2,6 +2,7 @@
 
 FROM oven/bun:1.3.12-slim AS deps
 WORKDIR /app
+ARG INSTALL_PLAYWRIGHT_CHROMIUM=true
 
 COPY package.json bun.lock ./
 COPY apps/api/package.json ./apps/api/package.json
@@ -12,10 +13,15 @@ RUN bun install --frozen-lockfile
 
 # Install Chromium for Playwright
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-RUN bunx playwright install chromium
+RUN if [ "$INSTALL_PLAYWRIGHT_CHROMIUM" = "true" ]; then \
+        bunx playwright install chromium; \
+    else \
+        mkdir -p /ms-playwright; \
+    fi
 
 FROM oven/bun:1.3.12-slim AS runner
 WORKDIR /app
+ARG INSTALL_PLAYWRIGHT_CHROMIUM=true
 
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
@@ -27,7 +33,9 @@ COPY apps/api ./apps/api
 COPY packages/contracts ./packages/contracts
 
 # Install OS-level Playwright dependencies
-RUN bunx playwright install-deps chromium
+RUN if [ "$INSTALL_PLAYWRIGHT_CHROMIUM" = "true" ]; then \
+        bunx playwright install-deps chromium; \
+    fi
 
 # Copy Playwright browsers into the runtime image
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright

--- a/apps/api/env.example
+++ b/apps/api/env.example
@@ -27,3 +27,7 @@ GOOGLE_CLOUD_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYourPrivateKeyHere\n-----
 
 # Base URL for serving product images (e.g. CDN or storage bucket public URL).
 IMAGE_BASE_URL=
+
+# Optional Chrome DevTools Protocol endpoint for PDF rendering.
+# Example: http://localhost:9222 or ws://browser:9222/devtools/browser/<id>
+PDF_BROWSER_CDP_URL=

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -26,6 +26,7 @@ const envSchema = z.object({
     GOOGLE_CLOUD_CLIENT_EMAIL: optionalString,
     GOOGLE_CLOUD_PRIVATE_KEY: optionalString,
     IMAGE_BASE_URL: z.string().default(""),
+    PDF_BROWSER_CDP_URL: optionalString,
 });
 
 export const env = envSchema.parse(process.env);

--- a/apps/api/src/lib/pdf/cdpPdf.ts
+++ b/apps/api/src/lib/pdf/cdpPdf.ts
@@ -1,0 +1,338 @@
+import type { ResolvedCompilePdfOptions } from "@/lib/pdf/compilePdf";
+
+type CdpError = {
+    message: string;
+    code?: number;
+};
+
+type CdpMessage<T = unknown> = {
+    id?: number;
+    method?: string;
+    params?: unknown;
+    result?: T;
+    error?: CdpError;
+    sessionId?: string;
+};
+
+type PendingCommand = {
+    resolve: (value: unknown) => void;
+    reject: (error: Error) => void;
+    timeout: Timer;
+};
+
+type CreateTargetResult = {
+    targetId: string;
+};
+
+type AttachToTargetResult = {
+    sessionId: string;
+};
+
+type GetFrameTreeResult = {
+    frameTree: {
+        frame: {
+            id: string;
+        };
+    };
+};
+
+type PrintToPdfResult = {
+    data: string;
+};
+
+const footerTemplate =
+    '<div style="font-size: 10px; text-align: right; width: 100%; padding-right: 12mm;"><span class="pageNumber"></span>/<span class="totalPages"></span></div>';
+
+const emptyHeaderTemplate = "<div></div>";
+
+const cdpCommandTimeoutMs = 30_000;
+
+class CdpConnection {
+    private nextId = 1;
+    private readonly pending = new Map<number, PendingCommand>();
+
+    private constructor(private readonly socket: WebSocket) {
+        this.socket.addEventListener("message", (event) => {
+            this.handleMessage(String(event.data));
+        });
+        this.socket.addEventListener("close", () => {
+            this.rejectAll(new Error("CDP websocket closed"));
+        });
+        this.socket.addEventListener("error", () => {
+            this.rejectAll(new Error("CDP websocket error"));
+        });
+    }
+
+    static async connect(webSocketUrl: string): Promise<CdpConnection> {
+        const socket = new WebSocket(webSocketUrl);
+
+        await new Promise<void>((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                reject(new Error(`Timed out connecting to ${webSocketUrl}`));
+                socket.close();
+            }, cdpCommandTimeoutMs);
+
+            socket.addEventListener(
+                "open",
+                () => {
+                    clearTimeout(timeout);
+                    resolve();
+                },
+                { once: true }
+            );
+            socket.addEventListener(
+                "error",
+                () => {
+                    clearTimeout(timeout);
+                    reject(new Error(`Failed to connect to ${webSocketUrl}`));
+                },
+                { once: true }
+            );
+        });
+
+        return new CdpConnection(socket);
+    }
+
+    async send<T>(
+        method: string,
+        params: Record<string, unknown> = {},
+        sessionId?: string
+    ): Promise<T> {
+        const id = this.nextId++;
+        const payload = JSON.stringify({ id, method, params, sessionId });
+
+        const response = new Promise<T>((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                this.pending.delete(id);
+                reject(
+                    new Error(`Timed out waiting for CDP command ${method}`)
+                );
+            }, cdpCommandTimeoutMs);
+
+            this.pending.set(id, {
+                resolve: (value) => resolve(value as T),
+                reject,
+                timeout,
+            });
+        });
+
+        this.socket.send(payload);
+        return response;
+    }
+
+    close(): void {
+        this.socket.close();
+    }
+
+    private handleMessage(rawMessage: string): void {
+        const message = JSON.parse(rawMessage) as CdpMessage;
+        if (!message.id) return;
+
+        const pending = this.pending.get(message.id);
+        if (!pending) return;
+
+        clearTimeout(pending.timeout);
+        this.pending.delete(message.id);
+
+        if (message.error) {
+            pending.reject(new Error(message.error.message));
+            return;
+        }
+
+        pending.resolve(message.result);
+    }
+
+    private rejectAll(error: Error): void {
+        for (const [id, pending] of this.pending.entries()) {
+            clearTimeout(pending.timeout);
+            pending.reject(error);
+            this.pending.delete(id);
+        }
+    }
+}
+
+export async function compilePdfFromHtmlWithCdp(
+    cdpUrl: string,
+    html: string,
+    options: ResolvedCompilePdfOptions
+): Promise<Uint8Array> {
+    const webSocketUrl = await resolveWebSocketDebuggerUrl(cdpUrl);
+    const connection = await CdpConnection.connect(webSocketUrl);
+    let targetId: string | undefined;
+
+    try {
+        const target = await connection.send<CreateTargetResult>(
+            "Target.createTarget",
+            { url: "about:blank" }
+        );
+        targetId = target.targetId;
+
+        const attached = await connection.send<AttachToTargetResult>(
+            "Target.attachToTarget",
+            { targetId, flatten: true }
+        );
+        const sessionId = attached.sessionId;
+
+        await connection.send("Page.enable", {}, sessionId);
+        await connection.send("Runtime.enable", {}, sessionId);
+
+        const frameTree = await connection.send<GetFrameTreeResult>(
+            "Page.getFrameTree",
+            {},
+            sessionId
+        );
+        await connection.send(
+            "Page.setDocumentContent",
+            {
+                frameId: frameTree.frameTree.frame.id,
+                html,
+            },
+            sessionId
+        );
+        await waitForPageAssets(connection, sessionId);
+
+        const pdf = await connection.send<PrintToPdfResult>(
+            "Page.printToPDF",
+            {
+                landscape: options.landscape,
+                printBackground: options.printBackground,
+                displayHeaderFooter: true,
+                headerTemplate: emptyHeaderTemplate,
+                footerTemplate,
+                ...formatToPaperSize(options.format),
+                ...marginToInches(options.margin),
+            },
+            sessionId
+        );
+
+        return new Uint8Array(Buffer.from(pdf.data, "base64"));
+    } finally {
+        if (targetId) {
+            await connection
+                .send("Target.closeTarget", { targetId })
+                .catch(() => undefined);
+        }
+        connection.close();
+    }
+}
+
+async function resolveWebSocketDebuggerUrl(cdpUrl: string): Promise<string> {
+    if (cdpUrl.startsWith("ws://") || cdpUrl.startsWith("wss://")) {
+        return cdpUrl;
+    }
+
+    const endpointUrl = new URL(cdpUrl);
+    const versionUrl = new URL("/json/version", endpointUrl);
+    const response = await fetch(versionUrl);
+    if (!response.ok) {
+        throw new Error(
+            `Failed to resolve CDP websocket URL: ${response.status} ${response.statusText}`
+        );
+    }
+
+    const version = (await response.json()) as {
+        webSocketDebuggerUrl?: string;
+    };
+
+    if (!version.webSocketDebuggerUrl) {
+        throw new Error(
+            "CDP /json/version did not return webSocketDebuggerUrl"
+        );
+    }
+
+    const webSocketUrl = new URL(version.webSocketDebuggerUrl);
+    if (
+        ["localhost", "127.0.0.1", "0.0.0.0"].includes(webSocketUrl.hostname) &&
+        !["localhost", "127.0.0.1"].includes(endpointUrl.hostname)
+    ) {
+        webSocketUrl.host = endpointUrl.host;
+    }
+
+    return webSocketUrl.toString();
+}
+
+async function waitForPageAssets(
+    connection: CdpConnection,
+    sessionId: string
+): Promise<void> {
+    await connection.send(
+        "Runtime.evaluate",
+        {
+            awaitPromise: true,
+            returnByValue: true,
+            expression: `(() => new Promise((resolve) => {
+                const done = () => {
+                    const images = Array.from(document.images);
+                    Promise.all(images.map((image) => {
+                        if (!image.complete) {
+                            return new Promise((imageDone) => {
+                                image.addEventListener("load", imageDone, { once: true });
+                                image.addEventListener("error", imageDone, { once: true });
+                            });
+                        }
+
+                        if (typeof image.decode !== "function") return undefined;
+                        return image.decode().catch(() => undefined);
+                    })).then(resolve);
+                };
+
+                if (document.readyState === "loading") {
+                    document.addEventListener("DOMContentLoaded", done, { once: true });
+                } else {
+                    done();
+                }
+
+                setTimeout(resolve, 5000);
+            }))()`,
+        },
+        sessionId
+    );
+}
+
+function formatToPaperSize(format: ResolvedCompilePdfOptions["format"]): {
+    paperWidth: number;
+    paperHeight: number;
+} {
+    if (format !== "A4") {
+        throw new Error(`Unsupported PDF format: ${format}`);
+    }
+
+    return {
+        paperWidth: 8.27,
+        paperHeight: 11.69,
+    };
+}
+
+function marginToInches(
+    margin: ResolvedCompilePdfOptions["margin"]
+): Record<string, number> {
+    return {
+        marginTop: cssLengthToInches(margin.top),
+        marginRight: cssLengthToInches(margin.right),
+        marginBottom: cssLengthToInches(margin.bottom),
+        marginLeft: cssLengthToInches(margin.left),
+    };
+}
+
+function cssLengthToInches(value: string): number {
+    const match = value.trim().match(/^(-?\d+(?:\.\d+)?)(mm|cm|in|px)$/);
+    if (!match) {
+        throw new Error(`Unsupported PDF margin value: ${value}`);
+    }
+
+    const amount = Number(match[1]);
+    const unit = match[2];
+
+    switch (unit) {
+        case "in":
+            return amount;
+        case "cm":
+            return amount / 2.54;
+        case "mm":
+            return amount / 25.4;
+        case "px":
+            return amount / 96;
+        default:
+            throw new Error(`Unsupported PDF margin unit: ${unit}`);
+    }
+}

--- a/apps/api/src/lib/pdf/compilePdf.ts
+++ b/apps/api/src/lib/pdf/compilePdf.ts
@@ -1,3 +1,4 @@
+import { env } from "@/env";
 import { getPlaywrightBrowser } from "@/lib/playwrightBrowser";
 
 export type CompilePdfOptions = {
@@ -32,7 +33,7 @@ export async function compilePdfFromHtml(
     html: string,
     options: CompilePdfOptions = {}
 ): Promise<Uint8Array> {
-    const browser = await getPlaywrightBrowser();
+    const browser = await getPlaywrightBrowser(env.PDF_BROWSER_CDP_URL);
     const context = await browser.newContext();
 
     try {

--- a/apps/api/src/lib/pdf/compilePdf.ts
+++ b/apps/api/src/lib/pdf/compilePdf.ts
@@ -1,4 +1,5 @@
 import { env } from "@/env";
+import { compilePdfFromHtmlWithCdp } from "@/lib/pdf/cdpPdf";
 import { getPlaywrightBrowser } from "@/lib/playwrightBrowser";
 
 export type CompilePdfOptions = {
@@ -29,24 +30,34 @@ const defaultOptions: Required<Omit<CompilePdfOptions, "landscape">> & {
     waitUntil: "networkidle",
 };
 
+export type ResolvedCompilePdfOptions = typeof defaultOptions;
+
 export async function compilePdfFromHtml(
     html: string,
     options: CompilePdfOptions = {}
 ): Promise<Uint8Array> {
-    const browser = await getPlaywrightBrowser(env.PDF_BROWSER_CDP_URL);
+    const resolvedOptions = {
+        ...defaultOptions,
+        ...options,
+        margin: {
+            ...defaultOptions.margin,
+            ...(options.margin ?? {}),
+        },
+    };
+
+    if (env.PDF_BROWSER_CDP_URL) {
+        return compilePdfFromHtmlWithCdp(
+            env.PDF_BROWSER_CDP_URL,
+            html,
+            resolvedOptions
+        );
+    }
+
+    const browser = await getPlaywrightBrowser();
     const context = await browser.newContext();
 
     try {
         const page = await context.newPage();
-
-        const resolvedOptions = {
-            ...defaultOptions,
-            ...options,
-            margin: {
-                ...defaultOptions.margin,
-                ...(options.margin ?? {}),
-            },
-        };
 
         await page.setContent(html, { waitUntil: resolvedOptions.waitUntil });
 

--- a/apps/api/src/lib/playwrightBrowser.ts
+++ b/apps/api/src/lib/playwrightBrowser.ts
@@ -5,13 +5,11 @@ declare global {
     var __playwrightBrowserPromise: Promise<Browser> | undefined;
 }
 
-export async function getPlaywrightBrowser(cdpUrl?: string): Promise<Browser> {
+export async function getPlaywrightBrowser(): Promise<Browser> {
     if (globalThis.__playwrightBrowser) return globalThis.__playwrightBrowser;
 
     if (!globalThis.__playwrightBrowserPromise) {
-        globalThis.__playwrightBrowserPromise = cdpUrl
-            ? chromium.connectOverCDP(cdpUrl)
-            : chromium.launch();
+        globalThis.__playwrightBrowserPromise = chromium.launch();
     }
 
     try {

--- a/apps/api/src/lib/playwrightBrowser.ts
+++ b/apps/api/src/lib/playwrightBrowser.ts
@@ -5,16 +5,22 @@ declare global {
     var __playwrightBrowserPromise: Promise<Browser> | undefined;
 }
 
-export async function getPlaywrightBrowser(): Promise<Browser> {
+export async function getPlaywrightBrowser(cdpUrl?: string): Promise<Browser> {
     if (globalThis.__playwrightBrowser) return globalThis.__playwrightBrowser;
 
     if (!globalThis.__playwrightBrowserPromise) {
-        globalThis.__playwrightBrowserPromise = chromium.launch();
+        globalThis.__playwrightBrowserPromise = cdpUrl
+            ? chromium.connectOverCDP(cdpUrl)
+            : chromium.launch();
     }
 
     try {
         globalThis.__playwrightBrowser =
             await globalThis.__playwrightBrowserPromise;
+        globalThis.__playwrightBrowser.on("disconnected", () => {
+            globalThis.__playwrightBrowser = undefined;
+            globalThis.__playwrightBrowserPromise = undefined;
+        });
         return globalThis.__playwrightBrowser;
     } catch (err) {
         globalThis.__playwrightBrowserPromise = undefined;


### PR DESCRIPTION
## Purpose
Move API PDF rendering to an externally managed Chrome DevTools Protocol browser by default, while keeping builtin Playwright Chromium available as an opt-in fallback.

## Key changes
- Add `PDF_BROWSER_CDP_URL` to API env parsing and docs.
- Use a native CDP PDF renderer over Bun WebSocket when `PDF_BROWSER_CDP_URL` is configured.
- Avoid `chromium.connectOverCDP` for CDP mode because Playwright’s bundled `ws` client times out under the Bun runtime against the sidecar CDP endpoint.
- Keep the existing Playwright `chromium.launch()` path for builtin Chromium fallback.
- Add `INSTALL_PLAYWRIGHT_CHROMIUM` Docker build arg and default it to `false` so API images skip bundled Chromium unless explicitly enabled.

## Migration / environment impacts
- CDP-based deployments should set `PDF_BROWSER_CDP_URL` at runtime.
- Deployments that still need bundled Chromium should build the API image with `--build-arg INSTALL_PLAYWRIGHT_CHROMIUM=true`.

## Validation
- `bun run format:check` passed.
- `cd apps/web && bun run lint` passed.
- `cd apps/api && bun run lint` passed.
- `cd apps/web && bun run test:unit` passed: 137 tests.
- `cd apps/api && bun run test:unit` passed: 4 tests.
- In-cluster native CDP PDF smoke test passed against the `kbw-productsdisplay-api` Chromium sidecar and returned a valid `%PDF-` buffer.

## Notes
- The Kubernetes sidecar must launch Chromium with remote debugging enabled, including `--remote-allow-origins=*`.