### PR TITLE
Fix E2E tests missing dependency

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,6 +44,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/bun": "^1.3.12",
+    "@types/node": "^25",
     "@types/pg": "^8.20.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",


### PR DESCRIPTION
Add @types/node to the web package dev dependencies so Next's TypeScript startup check passes when CI installs dependencies from apps/web before running Playwright e2e tests.